### PR TITLE
chore: add typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+import { Ajv, Options } from "ajv";
+
+export type ValidatorCompiler = (
+  externalSchemas: unknown,
+  options: Options,
+  cache: Options["cache"]
+) => Ajv;
+
+export declare function ValidatorSelector(): ValidatorCompiler;
+
+export type { Ajv, Options } from "ajv";
+
+export default ValidatorSelector;

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "1.0.0",
   "description": "Build and manage the AJV instances for the fastify framework",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "test"
   },
   "scripts": {
     "lint:fix": "standard --fix",
-    "test": "standard && tap --100 test/**/*.test.js"
+    "unit": "tap --100 test/**/*.test.js",
+    "test": "standard && npm run unit && npm run test:typescript",
+    "test:typescript": "tsd"
   },
   "repository": {
     "type": "git",
@@ -31,9 +34,13 @@
     "ajv-errors": "^1.0.1",
     "ajv-merge-patch": "^4.1.0",
     "standard": "^16.0.3",
-    "tap": "^15.0.1"
+    "tap": "^15.0.1",
+    "tsd": "^0.14.0"
   },
   "dependencies": {
     "ajv": "^6.12.6"
+  },
+  "tsd": {
+    "directory": "test/types"
   }
 }

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -1,0 +1,6 @@
+import { expectType } from "tsd";
+import ValidatorSelector, { ValidatorCompiler } from "../..";
+
+const compiler = ValidatorSelector();
+
+expectType<ValidatorCompiler>(compiler);


### PR DESCRIPTION
This typings is not totally correct. As `index.js` do not have `export default` but it is good to go for `fastify` typings usage.

If we use `export =` in the typings, we have no way to re-export `ajv`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
