### PR TITLE
docs: remove nullable default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ The Fastify's default [`ajv` options](https://github.com/ajv-validator/ajv/tree/
   removeAdditional: true,
   // Explicitly set allErrors to `false`.
   // When set to `true`, a DoS attack is possible.
-  allErrors: false,
-  nullable: true
+  allErrors: false
 }
 ```
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,6 +54,25 @@ t.test('basic usage', t => {
   t.equal(result, true)
 })
 
+t.test('nullable default', t => {
+  t.plan(2)
+  const factory = AjvCompiler()
+  const compiler = factory({}, fastifyAjvOptionsDefault)
+  const validatorFunc = compiler({
+    schema: {
+      type: 'object',
+      properties: {
+        nullable: { type: 'string', nullable: true },
+        notNullable: { type: 'string' }
+      }
+    }
+  })
+  const input = { nullable: null, notNullable: null }
+  const result = validatorFunc(input)
+  t.equal(result, true)
+  t.same(input, { nullable: null, notNullable: '' }, 'the notNullable field has been coerced')
+})
+
 t.test('plugin loading', t => {
   t.plan(3)
   const factory = AjvCompiler()


### PR DESCRIPTION
Removing the nullalble option since it has been removed from ajv >=7

https://github.com/ajv-validator/ajv/releases/tag/v7.0.0

> Removed options:
> - nullable: nullable keyword is supported by default.

