### PR TITLE
Ajv serializer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - 'docs/**'
       - '*.md'
 
+env:
+  TZ: 'UTC'
+
 jobs:
   test:
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3

--- a/README.md
+++ b/README.md
@@ -84,6 +84,30 @@ const app = fastify({
 
 The defaults AJV JTD options are the same as the [Fastify's default options](#AJV-Configuration).
 
+#### Fastify with JTD and serialization
+
+You can use JTD Schemas to serialize your response object too:
+
+```js
+const factoryValidator = require('@fastify/ajv-compiler')()
+const factorySerializer = require('@fastify/ajv-compiler')({ asSerializer: true })
+
+const app = fastify({
+  jsonShorthand: false,
+  ajv: {
+    customOptions: { }, // additional JTD options
+    mode: 'JTD'
+  },
+  schemaController: {
+    compilersFactory: {
+      buildValidator: factoryValidator,
+      buildSerializer: factorySerializer
+    }
+  }
+})
+```
+
+
 ### AJV Standalone
 
 AJV v8 introduces the [standalone feature](https://ajv.js.org/standalone.html) that let you to pre-compile your schemas and use them in your application for a faster startup.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can use JTD Schemas to serialize your response object too:
 
 ```js
 const factoryValidator = require('@fastify/ajv-compiler')()
-const factorySerializer = require('@fastify/ajv-compiler')({ asSerializer: true })
+const factorySerializer = require('@fastify/ajv-compiler')({ jtdSerializer: true })
 
 const app = fastify({
   jsonShorthand: false,

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The Fastify's default [`ajv` options](https://github.com/ajv-validator/ajv/tree/
 ```
 
 Moreover, the [`ajv-formats`](https://www.npmjs.com/package/ajv-formats) module is included by default.
-If you need to customize check the usage section below.
+If you need to customize it, check the _usage_ section below.
 
-To customize them, see how in the [Fastify official docs](https://www.fastify.io/docs/latest/Server/#ajv).
+To customize the `ajv`'s options, see how in the [Fastify official docs](https://www.fastify.io/docs/latest/Server/#ajv).
 
 
 ## Usage
@@ -178,7 +178,7 @@ This module provide a factory function to produce [Validator Compilers](https://
 
 The Fastify factory function is just one per server instance and it is called for every encapsulated context created by the application through the `fastify.register()` call.
 
-Every Validator Compiler produced has a dedicated AJV instance, so, this factory will try to produce as less as possible AJV instances to reduce the memory footprint and the startup time.
+Every Validator Compiler produced, has a dedicated AJV instance, so, this factory will try to produce as less as possible AJV instances to reduce the memory footprint and the startup time.
 
 The variables involved to choose if a Validator Compiler can be reused are:
 

--- a/benchmark/small-object.mjs
+++ b/benchmark/small-object.mjs
@@ -1,0 +1,37 @@
+import cronometro from 'cronometro'
+
+import fjs from 'fast-json-stringify'
+import AjvCompiler from '../index.js'
+
+const fjsSerialize = buildFJSSerializerFunction({
+  type: 'object',
+  properties: {
+    hello: { type: 'string' },
+    name: { type: 'string' }
+  }
+})
+const ajvSerialize = buildAJVSerializerFunction({
+  properties: {
+    hello: { type: 'string' },
+    name: { type: 'string' }
+  }
+})
+
+await cronometro({
+  'fast-json-stringify': function () {
+    fjsSerialize({ hello: 'Ciao', name: 'Manuel' })
+  },
+  'ajv serializer': function () {
+    ajvSerialize({ hello: 'Ciao', name: 'Manuel' })
+  }
+})
+
+function buildFJSSerializerFunction (schema) {
+  return fjs(schema)
+}
+
+function buildAJVSerializerFunction (schema) {
+  const factory = AjvCompiler({ jtdSerializer: true })
+  const compiler = factory({}, { customOptions: {} })
+  return compiler({ schema })
+}

--- a/index.js
+++ b/index.js
@@ -1,29 +1,16 @@
 'use strict'
 
-const fastUri = require('fast-uri')
-
 const AjvReference = Symbol.for('fastify.ajv-compiler.reference')
 const ValidatorCompiler = require('./lib/validator-compiler')
 const SerializerCompiler = require('./lib/serializer-compiler')
-
-const defaultAjvOptions = {
-  coerceTypes: 'array',
-  useDefaults: true,
-  removeAdditional: true,
-  uriResolver: fastUri,
-  addUsedSchema: false,
-  // Explicitly set allErrors to `false`.
-  // When set to `true`, a DoS attack is possible.
-  allErrors: false
-}
 
 function ValidatorSelector (opts) {
   const validatorPool = new Map()
   const serializerPool = new Map()
 
-  if (opts && opts.asSerializer === true) {
+  if (opts && opts.jtdSerializer === true) {
     return function buildSerializerFromPool (externalSchemas, serializerOpts) {
-      const uniqueAjvKey = getPoolKey(externalSchemas, serializerOpts)
+      const uniqueAjvKey = getPoolKey({}, serializerOpts)
       if (serializerPool.has(uniqueAjvKey)) {
         return serializerPool.get(uniqueAjvKey)
       }

--- a/index.js
+++ b/index.js
@@ -1,18 +1,7 @@
 'use strict'
 
-const Ajv = require('ajv').default
-const AjvJTD = require('ajv/dist/jtd')
-
 const AjvReference = Symbol.for('fastify.ajv-compiler.reference')
-
-const defaultAjvOptions = {
-  coerceTypes: true,
-  useDefaults: true,
-  removeAdditional: true,
-  // Explicitly set allErrors to `false`.
-  // When set to `true`, a DoS attack is possible.
-  allErrors: false
-}
+const ValidatorCompiler = require('./lib/validator-compiler')
 
 function ValidatorSelector () {
   const validatorPool = new Map()
@@ -35,54 +24,6 @@ function ValidatorSelector () {
     }
 
     return ret
-  }
-}
-
-class ValidatorCompiler {
-  constructor (externalSchemas, options) {
-    // This instance of Ajv is private
-    // it should not be customized or used
-    if (options.mode === 'JTD') {
-      this.ajv = new AjvJTD(Object.assign({}, defaultAjvOptions, options.customOptions))
-    } else {
-      this.ajv = new Ajv(Object.assign({}, defaultAjvOptions, options.customOptions))
-    }
-
-    let addFormatPlugin = true
-    if (options.plugins && options.plugins.length > 0) {
-      for (const plugin of options.plugins) {
-        if (Array.isArray(plugin)) {
-          addFormatPlugin = addFormatPlugin && plugin[0].name !== 'formatsPlugin'
-          plugin[0](this.ajv, plugin[1])
-        } else {
-          addFormatPlugin = addFormatPlugin && plugin.name !== 'formatsPlugin'
-          plugin(this.ajv)
-        }
-      }
-    }
-
-    if (addFormatPlugin) {
-      require('ajv-formats')(this.ajv)
-    }
-
-    const sourceSchemas = Object.values(externalSchemas)
-    for (const extSchema of sourceSchemas) {
-      this.ajv.addSchema(extSchema)
-    }
-  }
-
-  buildValidatorFunction ({ schema/*, method, url, httpPart */ }) {
-    // Ajv does not support compiling two schemas with the same
-    // id inside the same instance. Therefore if we have already
-    // compiled the schema with the given id, we just return it.
-    if (schema.$id) {
-      const stored = this.ajv.getSchema(schema.$id)
-      if (stored) {
-        return stored
-      }
-    }
-
-    return this.ajv.compile(schema)
   }
 }
 

--- a/lib/default-ajv-options.js
+++ b/lib/default-ajv-options.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = Object.freeze({
+  coerceTypes: true,
+  useDefaults: true,
+  removeAdditional: true,
+  // Explicitly set allErrors to `false`.
+  // When set to `true`, a DoS attack is possible.
+  allErrors: false
+})

--- a/lib/default-ajv-options.js
+++ b/lib/default-ajv-options.js
@@ -1,9 +1,13 @@
 'use strict'
 
+const fastUri = require('fast-uri');
+
 module.exports = Object.freeze({
-  coerceTypes: true,
+  coerceTypes: 'array',
   useDefaults: true,
   removeAdditional: true,
+  uriResolver: fastUri,
+  addUsedSchema: false,
   // Explicitly set allErrors to `false`.
   // When set to `true`, a DoS attack is possible.
   allErrors: false

--- a/lib/default-ajv-options.js
+++ b/lib/default-ajv-options.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fastUri = require('fast-uri');
+const fastUri = require('fast-uri')
 
 module.exports = Object.freeze({
   coerceTypes: 'array',

--- a/lib/serializer-compiler.js
+++ b/lib/serializer-compiler.js
@@ -8,10 +8,15 @@ class SerializerCompiler {
   constructor (externalSchemas, options) {
     this.ajv = new AjvJTD(Object.assign({}, defaultAjvOptions, options))
 
-    const sourceSchemas = Object.values(externalSchemas)
-    for (const extSchema of sourceSchemas) {
-      this.ajv.addSchema(extSchema)
-    }
+    /**
+     * https://ajv.js.org/json-type-definition.html#ref-form
+     * Unlike JSON Schema, JTD does not allow to reference:
+     * - any schema fragment other than root level definitions member
+     * - root of the schema - there is another way to define a self-recursive schema (see Example 2)
+     * - another schema file (but you can still combine schemas from multiple files using JavaScript).
+     *
+     * So we ignore the externalSchemas parameter.
+     */
   }
 
   buildSerializerFunction ({ schema/*, method, url, httpStatus */ }) {

--- a/lib/serializer-compiler.js
+++ b/lib/serializer-compiler.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const AjvJTD = require('ajv/dist/jtd')
+
+const defaultAjvOptions = require('./default-ajv-options')
+
+class SerializerCompiler {
+  constructor (externalSchemas, options) {
+    this.ajv = new AjvJTD(Object.assign({}, defaultAjvOptions, options))
+
+    const sourceSchemas = Object.values(externalSchemas)
+    for (const extSchema of sourceSchemas) {
+      this.ajv.addSchema(extSchema)
+    }
+  }
+
+  buildSerializerFunction ({ schema/*, method, url, httpStatus */ }) {
+    return this.ajv.compileSerializer(schema)
+  }
+}
+
+module.exports = SerializerCompiler

--- a/lib/validator-compiler.js
+++ b/lib/validator-compiler.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const Ajv = require('ajv').default
+const AjvJTD = require('ajv/dist/jtd')
+
+const defaultAjvOptions = {
+  coerceTypes: true,
+  useDefaults: true,
+  removeAdditional: true,
+  // Explicitly set allErrors to `false`.
+  // When set to `true`, a DoS attack is possible.
+  allErrors: false
+}
+
+class ValidatorCompiler {
+  constructor (externalSchemas, options) {
+    // This instance of Ajv is private
+    // it should not be customized or used
+    if (options.mode === 'JTD') {
+      this.ajv = new AjvJTD(Object.assign({}, defaultAjvOptions, options.customOptions))
+    } else {
+      this.ajv = new Ajv(Object.assign({}, defaultAjvOptions, options.customOptions))
+    }
+
+    let addFormatPlugin = true
+    if (options.plugins && options.plugins.length > 0) {
+      for (const plugin of options.plugins) {
+        if (Array.isArray(plugin)) {
+          addFormatPlugin = addFormatPlugin && plugin[0].name !== 'formatsPlugin'
+          plugin[0](this.ajv, plugin[1])
+        } else {
+          addFormatPlugin = addFormatPlugin && plugin.name !== 'formatsPlugin'
+          plugin(this.ajv)
+        }
+      }
+    }
+
+    if (addFormatPlugin) {
+      require('ajv-formats')(this.ajv)
+    }
+
+    const sourceSchemas = Object.values(externalSchemas)
+    for (const extSchema of sourceSchemas) {
+      this.ajv.addSchema(extSchema)
+    }
+  }
+
+  buildValidatorFunction ({ schema/*, method, url, httpPart */ }) {
+    // Ajv does not support compiling two schemas with the same
+    // id inside the same instance. Therefore if we have already
+    // compiled the schema with the given id, we just return it.
+    if (schema.$id) {
+      const stored = this.ajv.getSchema(schema.$id)
+      if (stored) {
+        return stored
+      }
+    }
+
+    return this.ajv.compile(schema)
+  }
+}
+
+module.exports = ValidatorCompiler

--- a/lib/validator-compiler.js
+++ b/lib/validator-compiler.js
@@ -3,14 +3,7 @@
 const Ajv = require('ajv').default
 const AjvJTD = require('ajv/dist/jtd')
 
-const defaultAjvOptions = {
-  coerceTypes: true,
-  useDefaults: true,
-  removeAdditional: true,
-  // Explicitly set allErrors to `false`.
-  // When set to `true`, a DoS attack is possible.
-  allErrors: false
-}
+const defaultAjvOptions = require('./default-ajv-options')
 
 class ValidatorCompiler {
   constructor (externalSchemas, options) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ajv-errors": "^3.0.0",
     "ajv-i18n": "^4.0.1",
     "ajv-merge-patch": "^5.0.1",
+    "cronometro": "^1.1.4",
     "fastify": "^4.0.0",
     "require-from-string": "^2.0.2",
     "rimraf": "^3.0.2",

--- a/test/serialization.test.js
+++ b/test/serialization.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+process.env.TZ = 'UTC'
+
 const t = require('tap')
 const fastify = require('fastify')
 const AjvCompiler = require('../index')
@@ -111,7 +113,7 @@ t.test('fastify integration within JTD serializer', async t => {
   }, async () => {
     return {
       id: '123',
-      createdAt: new Date(1999, 1, 1),
+      createdAt: new Date('1999-01-31T23:00:00.000Z'),
       karma: 42,
       isAdmin: true,
       remove: 'me'
@@ -189,7 +191,7 @@ t.test('fastify integration and cached serializer', async t => {
     }, async () => {
       return {
         id: '123',
-        createdAt: new Date(1999, 1, 1),
+        createdAt: new Date('1999-01-31T23:00:00.000Z'),
         karma: 42,
         isAdmin: true,
         remove: 'me'

--- a/test/serialization.test.js
+++ b/test/serialization.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-process.env.TZ = 'UTC'
-
 const t = require('tap')
 const fastify = require('fastify')
 const AjvCompiler = require('../index')

--- a/test/serialization.test.js
+++ b/test/serialization.test.js
@@ -21,6 +21,18 @@ const jtdSchema = {
 }
 
 const externalSchemas1 = Object.freeze({})
+const externalSchemas2 = Object.freeze({
+  foo: {
+    definitions: {
+      coordinates: {
+        properties: {
+          lat: { type: 'float32' },
+          lng: { type: 'float32' }
+        }
+      }
+    }
+  }
+})
 
 const fastifyAjvOptionsDefault = Object.freeze({
   customOptions: {}
@@ -28,7 +40,7 @@ const fastifyAjvOptionsDefault = Object.freeze({
 
 t.test('basic serializer usage', t => {
   t.plan(4)
-  const factory = AjvCompiler({ asSerializer: true })
+  const factory = AjvCompiler({ jtdSerializer: true })
   const compiler = factory(externalSchemas1, fastifyAjvOptionsDefault)
   const serializeFunc = compiler({ schema: jtdSchema })
   t.equal(serializeFunc({ version: '1', foo: 42 }), '{"version":"1","foo":42}')
@@ -37,9 +49,35 @@ t.test('basic serializer usage', t => {
   t.equal(serializeFunc({ version: '2', foo: ['not', 1, { string: 'string' }] }), '{"version":"2","foo":"not,1,[object Object]"}')
 })
 
-t.test('fastify integration within JTD validation', async t => {
+t.test('external schemas are ignored', t => {
+  t.plan(1)
+  const factory = AjvCompiler({ jtdSerializer: true })
+  const compiler = factory(externalSchemas2, fastifyAjvOptionsDefault)
+  const serializeFunc = compiler({
+    schema: {
+      definitions: {
+        coordinates: {
+          properties: {
+            lat: { type: 'float32' },
+            lng: { type: 'float32' }
+          }
+        }
+      },
+      properties: {
+        userLoc: { ref: 'coordinates' },
+        serverLoc: { ref: 'coordinates' }
+      }
+    }
+  })
+  t.equal(serializeFunc(
+    { userLoc: { lat: 50, lng: -90 }, serverLoc: { lat: -15, lng: 50 } }),
+  '{"userLoc":{"lat":50,"lng":-90},"serverLoc":{"lat":-15,"lng":50}}'
+  )
+})
+
+t.test('fastify integration within JTD serializer', async t => {
   const factoryValidator = AjvCompiler()
-  const factorySerializer = AjvCompiler({ asSerializer: true })
+  const factorySerializer = AjvCompiler({ jtdSerializer: true })
 
   const app = fastify({
     jsonShorthand: false,
@@ -78,6 +116,96 @@ t.test('fastify integration within JTD validation', async t => {
       isAdmin: true,
       remove: 'me'
     }
+  })
+
+  {
+    const res = await app.inject({
+      url: '/',
+      method: 'POST',
+      payload: {
+        version: '1',
+        foo: 'not a number'
+      }
+    })
+
+    t.equal(res.statusCode, 400)
+    t.same(res.json(), { version: 'undefined' })
+  }
+
+  {
+    const res = await app.inject({
+      url: '/',
+      method: 'POST',
+      payload: {
+        version: '1',
+        foo: 32
+      }
+    })
+
+    t.equal(res.statusCode, 200)
+    t.same(res.json(), {
+      id: '123',
+      createdAt: '1999-01-31T23:00:00.000Z',
+      karma: 42,
+      isAdmin: true
+    })
+  }
+})
+
+t.test('fastify integration and cached serializer', async t => {
+  const factoryValidator = AjvCompiler()
+  const factorySerializer = AjvCompiler({ jtdSerializer: true })
+
+  const app = fastify({
+    jsonShorthand: false,
+    ajv: {
+      customOptions: { },
+      mode: 'JTD'
+    },
+    schemaController: {
+      compilersFactory: {
+        buildValidator: factoryValidator,
+        buildSerializer: factorySerializer
+      }
+    }
+  })
+
+  app.register(async function plugin (app, opts) {
+    app.post('/', {
+      schema: {
+        body: jtdSchema,
+        response: {
+          200: {
+            properties: {
+              id: { type: 'string' },
+              createdAt: { type: 'timestamp' },
+              karma: { type: 'int32' },
+              isAdmin: { type: 'boolean' }
+            }
+          },
+          400: jtdSchema
+        }
+      }
+    }, async () => {
+      return {
+        id: '123',
+        createdAt: new Date(1999, 1, 1),
+        karma: 42,
+        isAdmin: true,
+        remove: 'me'
+      }
+    })
+  })
+
+  app.register(async function plugin (app, opts) {
+    app.post('/two', {
+      schema: {
+        body: jtdSchema,
+        response: {
+          400: jtdSchema
+        }
+      }
+    }, () => {})
   })
 
   {

--- a/test/serialization.test.js
+++ b/test/serialization.test.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const t = require('tap')
+const fastify = require('fastify')
+const AjvCompiler = require('../index')
+
+const jtdSchema = {
+  discriminator: 'version',
+  mapping: {
+    1: {
+      properties: {
+        foo: { type: 'uint8' }
+      }
+    },
+    2: {
+      properties: {
+        foo: { type: 'string' }
+      }
+    }
+  }
+}
+
+const externalSchemas1 = Object.freeze({})
+
+const fastifyAjvOptionsDefault = Object.freeze({
+  customOptions: {}
+})
+
+t.test('basic serializer usage', t => {
+  t.plan(4)
+  const factory = AjvCompiler({ asSerializer: true })
+  const compiler = factory(externalSchemas1, fastifyAjvOptionsDefault)
+  const serializeFunc = compiler({ schema: jtdSchema })
+  t.equal(serializeFunc({ version: '1', foo: 42 }), '{"version":"1","foo":42}')
+  t.equal(serializeFunc({ version: '2', foo: 'hello' }), '{"version":"2","foo":"hello"}')
+  t.equal(serializeFunc({ version: '3', foo: 'hello' }), '{"version":"3"}')
+  t.equal(serializeFunc({ version: '2', foo: ['not', 1, { string: 'string' }] }), '{"version":"2","foo":"not,1,[object Object]"}')
+})
+
+t.test('fastify integration within JTD validation', async t => {
+  const factoryValidator = AjvCompiler()
+  const factorySerializer = AjvCompiler({ asSerializer: true })
+
+  const app = fastify({
+    jsonShorthand: false,
+    ajv: {
+      customOptions: { },
+      mode: 'JTD'
+    },
+    schemaController: {
+      compilersFactory: {
+        buildValidator: factoryValidator,
+        buildSerializer: factorySerializer
+      }
+    }
+  })
+
+  app.post('/', {
+    schema: {
+      body: jtdSchema,
+      response: {
+        200: {
+          properties: {
+            id: { type: 'string' },
+            createdAt: { type: 'timestamp' },
+            karma: { type: 'int32' },
+            isAdmin: { type: 'boolean' }
+          }
+        },
+        400: jtdSchema
+      }
+    }
+  }, async () => {
+    return {
+      id: '123',
+      createdAt: new Date(1999, 1, 1),
+      karma: 42,
+      isAdmin: true,
+      remove: 'me'
+    }
+  })
+
+  {
+    const res = await app.inject({
+      url: '/',
+      method: 'POST',
+      payload: {
+        version: '1',
+        foo: 'not a number'
+      }
+    })
+
+    t.equal(res.statusCode, 400)
+    t.same(res.json(), { version: 'undefined' })
+  }
+
+  {
+    const res = await app.inject({
+      url: '/',
+      method: 'POST',
+      payload: {
+        version: '1',
+        foo: 32
+      }
+    })
+
+    t.equal(res.statusCode, 200)
+    t.same(res.json(), {
+      id: '123',
+      createdAt: '1999-01-31T23:00:00.000Z',
+      karma: 42,
+      isAdmin: true
+    })
+  }
+})


### PR DESCRIPTION
Opening this draft to get feedback.
Right now this feature works, it needs more testing (CI fails due to the coverage).

The notable code is on the `index` and `serializer-compiler` files, the `validator` is just a copy-paste

AJV-JTD can be used to serialize the JSON payloads: https://ajv.js.org/guide/getting-started.html#parsing-and-serializing-json

I'm not sure if it is good to include this feature in this package, or we should create a new package that:

- support `fast-json-stringify` by default
- let the user opt-in to `ajv-JTD` feature

What do you think?


Closes https://github.com/fastify/fastify/issues/3441