### PR TITLE
feat: use fast-uri with ajv

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const Ajv = require('ajv').default
 const AjvJTD = require('ajv/dist/jtd')
+const fastUri = require('fast-uri')
 
 const AjvReference = Symbol.for('fastify.ajv-compiler.reference')
 
@@ -9,6 +10,7 @@ const defaultAjvOptions = {
   coerceTypes: 'array',
   useDefaults: true,
   removeAdditional: true,
+  uriResolver: fastUri,
   // Explicitly set allErrors to `false`.
   // When set to `true`, a DoS attack is possible.
   allErrors: false

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
     "tsd": "^0.19.0"
   },
   "dependencies": {
-    "ajv": "^8.6.2",
-    "ajv-formats": "^2.1.1"
+    "ajv": "^8.10.0",
+    "ajv-formats": "^2.1.1",
+    "fast-uri": "^1.0.1"
   },
   "tsd": {
     "directory": "test/types"


### PR DESCRIPTION
Adds `fast-uri` with `ajv`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
