### PR TITLE
docs(readme): replace `fastify.io` links with `fastify.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ The Fastify's default [`ajv` options](https://github.com/ajv-validator/ajv/tree/
 Moreover, the [`ajv-formats`](https://www.npmjs.com/package/ajv-formats) module is included by default.
 If you need to customize it, check the _usage_ section below.
 
-To customize the `ajv`'s options, see how in the [Fastify official docs](https://www.fastify.io/docs/latest/Reference/Server/#ajv).
+To customize the `ajv`'s options, see how in the [Fastify official docs](https://www.fastify.dev/docs/latest/Reference/Server/#ajv).
 
 
 ## Usage
 
 This module is already used as default by Fastify. 
-If you need to provide to your server instance a different version, refer to [the official doc](https://www.fastify.io/docs/latest/Reference/Server/#schemacontroller).
+If you need to provide to your server instance a different version, refer to [the official doc](https://www.fastify.dev/docs/latest/Reference/Server/#schemacontroller).
 
 ### Customize the `ajv-formats` plugin
 
@@ -203,7 +203,7 @@ app.listen({ port: 3000 })
 
 ### How it works
 
-This module provide a factory function to produce [Validator Compilers](https://www.fastify.io/docs/latest/Reference/Server/#validatorcompiler) functions.
+This module provide a factory function to produce [Validator Compilers](https://www.fastify.dev/docs/latest/Reference/Server/#validatorcompiler) functions.
 
 The Fastify factory function is just one per server instance and it is called for every encapsulated context created by the application through the `fastify.register()` call.
 
@@ -211,7 +211,7 @@ Every Validator Compiler produced, has a dedicated AJV instance, so, this factor
 
 The variables involved to choose if a Validator Compiler can be reused are:
 
-- the AJV configuration: it is [one per server](https://www.fastify.io/docs/latest/Reference/Server/#ajv)
+- the AJV configuration: it is [one per server](https://www.fastify.dev/docs/latest/Reference/Server/#ajv)
 - the external JSON schemas: once a new schema is added to a fastify's context, calling `fastify.addSchema()`, it will cause a new AJV inizialization
 
 


### PR DESCRIPTION
Fastify's domain extension has changed from `.io` to `.dev`. Whilst we have redirects in place it's still good to just swap them out.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
