### PR TITLE
fix: do not overwrite customOptions.formats

### DIFF
--- a/lib/validator-compiler.js
+++ b/lib/validator-compiler.js
@@ -30,6 +30,11 @@ class ValidatorCompiler {
 
     if (addFormatPlugin) {
       require('ajv-formats')(this.ajv)
+      if (options.customOptions && options.customOptions.formats) {
+        for (const [formatName, format] of Object.entries(options.customOptions.formats)) {
+          this.ajv.addFormat(formatName, format)
+        }
+      }
     }
 
     const sourceSchemas = Object.values(externalSchemas)

--- a/lib/validator-compiler.js
+++ b/lib/validator-compiler.js
@@ -30,7 +30,7 @@ class ValidatorCompiler {
 
     if (addFormatPlugin) {
       require('ajv-formats')(this.ajv)
-      if (options.customOptions && options.customOptions.formats) {
+      if (options.customOptions?.formats) {
         for (const [formatName, format] of Object.entries(options.customOptions.formats)) {
           this.ajv.addFormat(formatName, format)
         }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,6 +45,14 @@ const fastifyAjvOptionsCustom = Object.freeze({
   ]
 })
 
+const fastifyAjvCustomOptionsFormats = Object.freeze({
+  customOptions: {
+    formats: {
+      date: /foo/
+    }
+  }
+})
+
 t.test('basic usage', t => {
   t.plan(1)
   const factory = AjvCompiler()
@@ -118,6 +126,23 @@ t.test('plugin loading', t => {
   const resultFail = validatorFunc({})
   t.equal(resultFail, false)
   t.equal(validatorFunc.errors[0].message, 'hello world')
+})
+
+t.test('customOptions.formats have precedence', t => {
+  t.plan(2)
+  const factory = AjvCompiler()
+  const compiler1 = factory(externalSchemas1, fastifyAjvCustomOptionsFormats)
+  const validatorFunc = compiler1({
+    schema: {
+      type: 'string',
+      format: 'date'
+    }
+  })
+  const result = validatorFunc('foo')
+  t.equal(result, true)
+
+  const resultFail = validatorFunc('2016-10-02')
+  t.equal(resultFail, false)
 })
 
 t.test('optimization - cache ajv instance', t => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

[Issue: Custom format for ajv gets overwritten by ajv-formats](https://github.com/fastify/fastify/issues/5512)