### PR TITLE
Revert "build(deps): bump ajv-formats from 2.1.1 to 3.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "ajv": "^8.11.0",
-    "ajv-formats": "^3.0.1",
+    "ajv-formats": "^2.1.1",
     "fast-uri": "^2.0.0"
   }
 }


### PR DESCRIPTION
Reverts fastify/ajv-compiler#119

This would be a breaking.

Let me land a minor (v3.6.0) and we can merge `next` into `main` and bump a major 👍🏼 