### PR TITLE
docs(readme): update ci badge syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @fastify/ajv-compiler
 
+[![CI](https://github.com/fastify/ajv-compiler/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/fastify/ajv-compiler/actions/workflows/ci.yml)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
-[![Continuous Integration](https://github.com/fastify/ajv-compiler/workflows/Continuous%20Integration/badge.svg)](https://github.com/fastify/ajv-compiler/actions/workflows/ci.yml)
 
 This module manages the [`ajv`](https://www.npmjs.com/package/ajv) instances for the Fastify framework.
 It isolates the `ajv` dependency so that the AJV version is not tightly coupled to the Fastify version.


### PR DESCRIPTION
Syntax has changed, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge