### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ajv-i18n": "^4.2.0",
     "ajv-merge-patch": "^5.0.1",
     "cronometro": "^4.0.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.11.9",
     "require-from-string": "^2.0.2",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.