### PR TITLE
fix: enrich type definition of buildCompilerFromPool method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,10 +14,10 @@ type SharedCompilerOptions = {
   plugins?: Plugin<unknown>[];
 }
 
-declare function buildCompilerFromPool (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: SharedCompilerOptions & { mode: 'JTD'; customOptions?: JTDOptions }): AjvCompile
-declare function buildCompilerFromPool (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: SharedCompilerOptions & { mode?: never; customOptions?: AjvOptions }): AjvCompile
+type BuildAjvJtdCompilerFromPool = (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: SharedCompilerOptions & { mode: 'JTD'; customOptions?: JTDOptions }) => AjvCompile
+type BuildAjvCompilerFromPool = (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: SharedCompilerOptions & { mode?: never; customOptions?: AjvOptions }) => AjvCompile
 
-declare function buildSerializerFromPool (externalSchemas: any, serializerOpts?: { mode?: never; } & JTDOptions): AjvJTDCompile
+type BuildJtdSerializerFromPool = (externalSchemas: any, serializerOpts?: { mode?: never; } & JTDOptions) => AjvJTDCompile
 
 declare function AjvCompiler (opts: { jtdSerializer: true }): AjvCompiler.BuildSerializerFromPool
 declare function AjvCompiler (opts?: { jtdSerializer?: false }): AjvCompiler.BuildCompilerFromPool
@@ -28,9 +28,9 @@ declare namespace AjvCompiler {
   export type { Options, ErrorObject }
   export { Ajv }
 
-  export type BuildSerializerFromPool = typeof buildSerializerFromPool
+  export type BuildSerializerFromPool = BuildJtdSerializerFromPool
 
-  export type BuildCompilerFromPool = typeof buildCompilerFromPool
+  export type BuildCompilerFromPool = BuildAjvCompilerFromPool & BuildAjvJtdCompilerFromPool
 
   export const AjvReference: Symbol
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import _ajv, { AnySchema, Options as AjvOptions, ValidateFunction } from 'ajv'
+import _ajv, { AnySchema, Options as AjvOptions, ValidateFunction, Plugin } from 'ajv'
 import AjvJTD, { JTDOptions } from 'ajv/dist/jtd'
 import type { Options, ErrorObject } from 'ajv'
 import { AnyValidateFunction } from 'ajv/dist/core'
@@ -9,8 +9,13 @@ type AjvSerializerGenerator = typeof AjvCompiler
 type AjvJTDCompile = AjvJTD['compileSerializer']
 type AjvCompile = (schema: AnySchema, _meta?: boolean) => AnyValidateFunction
 
-declare function buildCompilerFromPool (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: { mode: 'JTD'; customOptions?: JTDOptions; onCreate?: (ajvInstance: Ajv) => void }): AjvCompile
-declare function buildCompilerFromPool (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: { mode?: never; customOptions?: AjvOptions; onCreate?: (ajvInstance: Ajv) => void }): AjvCompile
+type SharedCompilerOptions = {
+  onCreate?: (ajvInstance: Ajv) => void;
+  plugins?: Plugin<unknown>[];
+}
+
+declare function buildCompilerFromPool (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: SharedCompilerOptions & { mode: 'JTD'; customOptions?: JTDOptions }): AjvCompile
+declare function buildCompilerFromPool (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: SharedCompilerOptions & { mode?: never; customOptions?: AjvOptions }): AjvCompile
 
 declare function buildSerializerFromPool (externalSchemas: any, serializerOpts?: { mode?: never; } & JTDOptions): AjvJTDCompile
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -224,3 +224,22 @@ expectType<Symbol>(AjvReference)
   expectAssignable<ValidatorCompiler>(compiler)
   expectType<AnyValidateFunction<any>>(compiler(endpointSchema))
 }
+
+// Plugins
+{
+  const factory = AjvCompiler()
+  const compiler = factory({}, {
+    plugins: [
+      (ajv) => {
+        expectType<import('ajv').default>(ajv)
+        return ajv
+      },
+      (ajv, options) => {
+        expectType<import('ajv').default>(ajv)
+        expectType<unknown>(options)
+        return ajv
+      }
+    ]
+  })
+  expectAssignable<ValidatorCompiler>(compiler)
+}


### PR DESCRIPTION
Enriches type definition for buildCompilerFromPool method to better represent fastify/ajv-compiler features.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
