### PR TITLE
fix: plugins may contain also tuples of <plugin, options>

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,7 @@ type AjvCompile = (schema: AnySchema, _meta?: boolean) => AnyValidateFunction
 
 type SharedCompilerOptions = {
   onCreate?: (ajvInstance: Ajv) => void;
-  plugins?: Plugin<unknown>[];
+  plugins?: (Plugin<unknown> | [Plugin<unknown>, unknown])[];
 }
 
 type BuildAjvJtdCompilerFromPool = (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: SharedCompilerOptions & { mode: 'JTD'; customOptions?: JTDOptions }) => AjvCompile

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -238,7 +238,19 @@ expectType<Symbol>(AjvReference)
         expectType<import('ajv').default>(ajv)
         expectType<unknown>(options)
         return ajv
-      }
+      },
+      [
+        (ajv) => {
+          expectType<import('ajv').default>(ajv)
+          return ajv
+        }, ['keyword1', 'keyword2']
+      ],
+      [
+        (ajv) => {
+          expectType<import('ajv').default>(ajv)
+          return ajv
+        }, [{ key: 'value' }]
+      ],
     ]
   })
   expectAssignable<ValidatorCompiler>(compiler)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Hi there, terribly sorry about this, but I introduced a bug in typings with [https://github.com/fastify/ajv-compiler/pull/156]( https://github.com/fastify/ajv-compiler/pull/156).
Luckily fastify tests were extensive enough to cover also what i missed.

I have added more tests to reproduce what was erroring in fastify and fixed the typing definition for the plugins parameter

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
