### PR TITLE
fix: BuildCompilerFromPool function overloading type errors

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,9 +13,19 @@ type SharedCompilerOptions = {
   onCreate?: (ajvInstance: Ajv) => void;
   plugins?: (Plugin<unknown> | [Plugin<unknown>, unknown])[];
 }
+type JdtCompilerOptions = SharedCompilerOptions & {
+  mode: 'JTD';
+  customOptions?: JTDOptions
+}
+type AjvCompilerOptions = SharedCompilerOptions & {
+  mode?: never;
+  customOptions?: AjvOptions
+}
 
-type BuildAjvJtdCompilerFromPool = (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: SharedCompilerOptions & { mode: 'JTD'; customOptions?: JTDOptions }) => AjvCompile
-type BuildAjvCompilerFromPool = (externalSchemas: { [key: string]: AnySchema | AnySchema[] }, options?: SharedCompilerOptions & { mode?: never; customOptions?: AjvOptions }) => AjvCompile
+type BuildAjvOrJdtCompilerFromPool = (
+  externalSchemas: { [key: string]: AnySchema | AnySchema[] },
+  options?: JdtCompilerOptions | AjvCompilerOptions
+) => AjvCompile
 
 type BuildJtdSerializerFromPool = (externalSchemas: any, serializerOpts?: { mode?: never; } & JTDOptions) => AjvJTDCompile
 
@@ -30,7 +40,7 @@ declare namespace AjvCompiler {
 
   export type BuildSerializerFromPool = BuildJtdSerializerFromPool
 
-  export type BuildCompilerFromPool = BuildAjvCompilerFromPool & BuildAjvJtdCompilerFromPool
+  export type BuildCompilerFromPool = BuildAjvOrJdtCompilerFromPool
 
   export const AjvReference: Symbol
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Here i am once again!
The function overload definition edit suggested in #156 brought additional type errors in fastify because of how ts handles signatures overload.

![thanos-thinking](https://github.com/user-attachments/assets/24c1bdb6-d700-40b9-8f99-00c72a3c603b)

What i did:
1. Added more tests to reproduce the different usages.
2. Tested reverting to the old function declarations that were in place before #156, which failed the new tests.
3. Tested various approaches with interface and types to try and preserve the function signature overloading logic.
4. Finally changed approach to manually define a single function signature, with the type union for the specific parameter, without actually using signature overload.

It works, but what did it cost? 

![thanos-infinity-war](https://github.com/user-attachments/assets/2bc26b81-a513-4fd3-a99f-70a589c5d114)

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
