### PR TITLE
fix: Updates to fast-uri 3.1.2 to fix vulns CVE-2026-6321 and CVE-2026-6322

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
   "dependencies": {
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",
-    "fast-uri": "^3.0.0"
+    "fast-uri": "^3.1.2"
   }
 }


### PR DESCRIPTION
Updates fast-uri to fix vulns CVE-2026-6321 and CVE-2026-6322

## Testing 
Ran unit tests
```bash
uses TypeScript 6.0.3 with baseline TSConfig

pass ./types/index.tst.ts

Targets:    1 passed, 1 total
Test files: 1 passed, 1 total
Assertions: 54 passed, 54 total
Duration:   0.4s
```

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
